### PR TITLE
Rewrite ngram implementation with an eye for cpp11 performance

### DIFF
--- a/src/code.cpp
+++ b/src/code.cpp
@@ -1,87 +1,92 @@
 #include <cpp11.hpp>
 #include <string>
-using namespace cpp11;
 
-writable::strings ngram_single(strings x, int n, std::string delim_string) {
+static
+void
+fill_one_ngram(const cpp11::strings& x,
+               int n,
+               const std::string& delim,
+               cpp11::writable::strings& out,
+               R_xlen_t& loc) {
+  const R_xlen_t x_size = x.size();
+  const R_xlen_t range = std::max(x_size - n + 1, static_cast<R_xlen_t>(0));
 
-  if (n == 1) {
-    return(x);
-  }
+  // Not strictly necessary to call `unwind_protect()` here because we also
+  // call it in `cpp11_ngram()`, but it seems like it would be good practice
+  // to call it here too because this is where we leave cpp11 and use the less
+  // safe but faster R API directly.
+  cpp11::unwind_protect([&] {
+    for (R_xlen_t i = 0; i < range; ++i) {
+      // `x[i]` goes through `r_string`, and that is too expensive because
+      // generating each `r_string` involves protecting each CHARSXP.
+      std::string elt = CHAR(STRING_ELT(x, i));
 
-  int len = x.size();
-  int range = std::max(len - n + 1, 0);
+      for (R_xlen_t j = 1; j < n; ++j) {
+        const std::string piece = CHAR(STRING_ELT(x, i + j));
+        elt = elt + delim + piece;
+      }
 
-  writable::strings res (range);
-
-  if (range == 0) {
-    return(res);
-  }
-
-  for (int i = 0; i < range; ++i) {
-    std::string elt = cpp11::r_string(x[i]);
-    for(int j = 1; j < n; ++j) {
-      std::string elt_other = cpp11::r_string(x[i + j]);
-      elt = elt + delim_string + elt_other;
+      // `out[i] = elt` would approximately do the same thing, but it goes
+      // through `std::string elt` -> `r_string` before assigning, and that
+      // again involves protecting each `r_string`, which is expensive and not
+      // necessary.
+      SET_STRING_ELT(out, loc, Rf_mkCharLenCE(elt.data(), elt.size(), CE_UTF8));
+      ++loc;
     }
-    res[i] = elt;
-  }
-
-  return(res);
+  });
 }
 
-
-strings ngram(strings x, int n, int n_min, std::string delim_string) {
-
-  // The following 5 lines of code was done to pre-allocate
-  // I will try to convert to push_back()
-  int res_len = 0;
-  int x_len = x.size();
-
-  for (int i = n_min; i <= n; ++i) {
-    res_len += std::max(x_len - i + 1, 0);
-  }
-
-  writable::strings res (res_len);
-  writable::strings temp_res;
-  int index = 0;
+static
+cpp11::writable::strings
+ngram(const cpp11::strings& x,
+      int n,
+      int n_min,
+      const std::string& delim) {
+  R_xlen_t out_size = 0;
+  const R_xlen_t x_size = x.size();
 
   for (int i = n_min; i <= n; ++i) {
-
-    temp_res = ngram_single(x, i, delim_string);
-    int temp_res_len = temp_res.size();
-
-    for(int j = 0; j < temp_res_len; ++j) {
-      res[index] = cpp11::r_string(temp_res[j]);
-      ++index;
-      // res.push_back(temp_res[j]);
-    }
+    out_size += std::max(x_size - i + 1, static_cast<R_xlen_t>(0));
   }
 
-  return(res);
+  cpp11::writable::strings out(out_size);
+  R_xlen_t loc = 0;
+
+  for (int i = n_min; i <= n; ++i) {
+    fill_one_ngram(x, i, delim, out, loc);
+  }
+
+  return(out);
 }
 
 [[cpp11::register]]
-list cpp11_ngram(list x, int n, int n_min, cpp11::r_string delim) {
-
-  std::string delim_string = cpp11::as_cpp<std::string>(delim);
-
+cpp11::writable::list_of<cpp11::writable::strings>
+cpp11_ngram(cpp11::list_of<cpp11::strings> x,
+            int n,
+            int n_min,
+            std::string delim) {
   if (n <= 0) {
-    stop("n must be a positive integer.");
+    cpp11::stop("n must be a positive integer.");
   }
-
   if (n_min <= 0) {
-    stop("n_min must be a positive integer.");
+    cpp11::stop("n_min must be a positive integer.");
   }
-
   if (n_min > n) {
-    stop("n_min must be larger then n.");
+    cpp11::stop("n_min must be larger then n.");
   }
 
-  int len = x.size();
-  writable::list res (len);
+  const R_xlen_t x_size = x.size();
+  cpp11::writable::list_of<cpp11::writable::strings> out(x_size);
 
-  for (int i = 0; i < len; ++i) {
-    res[i] = ngram(x[i], n, n_min, delim_string);
-  }
-  return(res);
+  // Calling `unwind_protect()` here because each call to `ngram()` allocates
+  // a `cpp11::writable::strings` vector, and that allocation calls
+  // `unwind_protect()` too, so `unwind_protect()` would be run `x_size` times.
+  // Calling it here "turns off" the nested inner calls to it.
+  cpp11::unwind_protect([&] {
+    for (R_xlen_t i = 0; i < x_size; ++i) {
+      out[i] = ngram(x[i], n, n_min, delim);
+    }
+  });
+
+  return(out);
 }

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -6,10 +6,10 @@
 #include <R_ext/Visibility.h>
 
 // code.cpp
-list cpp11_ngram(list x, int n, int n_min, cpp11::r_string delim);
+cpp11::writable::list_of<cpp11::writable::strings> cpp11_ngram(cpp11::list_of<cpp11::strings> x, int n, int n_min, std::string delim);
 extern "C" SEXP _cpp11ngram_cpp11_ngram(SEXP x, SEXP n, SEXP n_min, SEXP delim) {
   BEGIN_CPP11
-    return cpp11::as_sexp(cpp11_ngram(cpp11::as_cpp<cpp11::decay_t<list>>(x), cpp11::as_cpp<cpp11::decay_t<int>>(n), cpp11::as_cpp<cpp11::decay_t<int>>(n_min), cpp11::as_cpp<cpp11::decay_t<cpp11::r_string>>(delim)));
+    return cpp11::as_sexp(cpp11_ngram(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::strings>>>(x), cpp11::as_cpp<cpp11::decay_t<int>>(n), cpp11::as_cpp<cpp11::decay_t<int>>(n_min), cpp11::as_cpp<cpp11::decay_t<std::string>>(delim)));
   END_CPP11
 }
 


### PR DESCRIPTION
I ended up doing a full rewrite so you can see what I did to directly fill the output vector on each ngram iteration rather than creating and returning a temporary vector each time. And so you can see the style i use for C++

It is probably "good enough" for now, but will get better when https://github.com/r-lib/cpp11/pull/299 is fixed

Knowing when to `unwind_protect()` and when to avoid expensive (but safe) cpp11 wrappers does make this pretty challenging to get right.

With CRAN cpp11 (0.4.3)

``` r
library(friends)

friends_data <- friends::friends |>
  dplyr::slice(1:10000) |>
  dplyr::pull(text) |>
  stringr::str_split(" ")

bench::mark(
  new = cpp11ngram:::cpp11_ngram(friends_data, n = 2L, n_min = 1, delim = "_"),
  old = textrecipes:::rcpp_ngram(friends_data, n = 2L, n_min = 1, delim = "_"),
  iterations = 50
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new          53.2ms   59.6ms      16.5    1.43MB    0.337
#> 2 old          30.5ms   34.2ms      29.2    1.84MB    1.87
```

With https://github.com/r-lib/cpp11/pull/299, where the nested `unwind_protect()` bug is fixed:

```r
bench::mark(
  new = cpp11ngram:::cpp11_ngram(friends_data, n = 2L, n_min = 1, delim = "_"),
  old = textrecipes:::rcpp_ngram(friends_data, n = 2L, n_min = 1, delim = "_"),
  iterations = 50
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new          34.1ms   37.9ms      26.4    1.43MB     1.69
#> 2 old          32.7ms   36.5ms      27.3    1.84MB     3.04
```